### PR TITLE
Change required dependency: Discord.js `^13.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/acegoal07/discordjs-pagination#readme",
   "dependencies": {
-    "discord.js": "^13.0.1"
+    "discord.js": "^13.5.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 
 <h1 id="about">About</h1>
 
-Required dependencies: 
+Required dependency: 
 - discord.js version 13.5.0^
 
 To install use:

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
 
 **1.0.9 contained changes that requires you to update your code to support the new version find the universal example <a href="#example">here</a> the change is very simple but makes using the dependency easier**
 
-Required dependencies: 
+Required dependency: 
 - discord.js version 13.5.0^
 
 To install use:

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@
 **1.0.9 contained changes that requires you to update your code to support the new version find the universal example <a href="#example">here</a> the change is very simple but makes using the dependency easier**
 
 Required dependencies: 
-- discord.js version 13.0.1^
+- discord.js version 13.5.0^
 
 To install use:
 ```js


### PR DESCRIPTION
Passing object to Discord.js 13.4.0 and below isn't supported