### PR TITLE
Added author independency

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const MessagePagination = require('./lib/message');
  * @param {Boolean} progressBar - ProgressBar settings
  * @param {String} proSlider - The symbol used to symbolise position on the progressBar
  * @param {String} proBar - The symbol used to symbolise pages to go on the progressBar
+ * @param {Boolean} authorIndependent - Only the author can use pagination
  * @returns {MessageEmbed[]} The pagination
 */
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -34,7 +35,8 @@ module.exports = pagination = async({
    privateReply = false,
    progressBar = false,
    proSlider = "▣",
-   proBar = "▢"
+   proBar = "▢",
+   authorIndependent = true
 }) => {   
    // deprecated pages
    if (!pageList && typeof pages === "object") {
@@ -61,7 +63,7 @@ module.exports = pagination = async({
       if (pageList.length < 2) return replyMessage ? message.reply({embeds: [pageList[0]]}) : message.channel.send({embeds: [pageList[0]]});
       if (replyMessage && privateReply) process.emitWarning("The privateReply setting overwrites and disables replyMessage setting");
       // Run
-      return MessagePagination(message, pageList, buttonList, timeout, replyMessage, autoDelete, privateReply, progressBar, proSlider, proBar);
+      return MessagePagination(message, pageList, buttonList, timeout, replyMessage, autoDelete, privateReply, progressBar, proSlider, proBar, authorIndependent);
    }
    // Interaction
    // Checks
@@ -76,5 +78,5 @@ module.exports = pagination = async({
    if (interaction.ephemeral && buttonList.length === 3 || interaction.ephemeral && buttonList.length === 5) throw new Error("Delete buttons are not supported by embeds with ephemeral enabled");
    if (interaction.ephemeral && autoDelete) throw new Error("Auto delete is not supported by embeds with ephemeral enabled");
    // Run
-   return InteractionPagination(interaction, pageList, buttonList, timeout, autoDelete, privateReply, progressBar, proSlider, proBar);
+   return InteractionPagination(interaction, pageList, buttonList, timeout, autoDelete, privateReply, progressBar, proSlider, proBar, authorIndependent);
 }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = pagination = async({
    progressBar = false,
    proSlider = "▣",
    proBar = "▢",
-   authorIndependent = true
+   authorIndependent = false
 }) => {   
    // deprecated pages
    if (!pageList && typeof pages === "object") {

--- a/lib/interaction.js
+++ b/lib/interaction.js
@@ -20,13 +20,16 @@ const progressBarBuilder = require('../util/progressBarBuilder');
  * @param {Boolean} progressBar - ProgressBar settings
  * @param {String} proSlider - The symbol used to symbolise position on the progressBar
  * @param {String} proBar - The symbol used to symbolise pages to go on the progressBar
+ * @param {Boolean} authorIndependent - Only the author can use pagination
  * @returns {MessageEmbed[]} The pagination
 */
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Interaction pagination ////////////////////////////////////////////////////////////////////////////////////////////////
-module.exports = InteractionPagination = async(interaction, pageList, buttonList, timeout, autoDelete, privateReply, progressBar, proSlider, proBar) => {
+module.exports = InteractionPagination = async(interaction, pageList, buttonList, timeout, autoDelete, privateReply, progressBar, proSlider, proBar, authorIndependent) => {
    // Set page number
    let pageNumber = 0;
+   // Get author ID
+   const authorID = interaction.user.id || interaction.member.user.id;
    // Create embed
    const row = new MessageActionRow().addComponents(buttonList);
    const embedInfo = {
@@ -47,25 +50,33 @@ module.exports = InteractionPagination = async(interaction, pageList, buttonList
    if (buttonList.length === 2) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
-         i.customId === buttonList[1].customId;
+         i.customId === buttonList[1].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else if (buttonList.length === 3) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
-         i.customId === buttonList[2].customId;
+         i.customId === buttonList[2].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else if (buttonList.length === 4) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
          i.customId === buttonList[2].customId ||
-         i.customId === buttonList[3].customId;
+         i.customId === buttonList[3].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
          i.customId === buttonList[2].customId ||
          i.customId === buttonList[3].customId ||
-         i.customId === buttonList[4].customId;
+         i.customId === buttonList[4].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    }
    // Create collector
    const collector = await curPage.createMessageComponentCollector({

--- a/lib/message.js
+++ b/lib/message.js
@@ -21,13 +21,16 @@ const progressBarBuilder = require('../util/progressBarBuilder');
  * @param {Boolean} progressBar - ProgressBar settings
  * @param {String} proSlider - The symbol used to symbolise position on the progressBar
  * @param {String} proBar - The symbol used to symbolise pages to go on the progressBar
+ * @param {Boolean} authorIndependent - Only the author can use pagination
  * @returns {MessageEmbed[]} The pagination
 */
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Message pagination ////////////////////////////////////////////////////////////////////////////////////////////////////
-module.exports = MessagePagination = async(message, pageList, buttonList, timeout, replyMessage, autoDelete, privateReply, progressBar, proSlider, proBar) => {
+module.exports = MessagePagination = async(message, pageList, buttonList, timeout, replyMessage, autoDelete, privateReply, progressBar, proSlider, proBar, authorIndependent) => {
    // Set page number
    let pageNumber = 0;
+   // Get author ID
+   const authorID = message.author.id;
    // Create embed
    const row = new MessageActionRow().addComponents(buttonList);
    const curPageContent = {
@@ -46,25 +49,33 @@ module.exports = MessagePagination = async(message, pageList, buttonList, timeou
    if (buttonList.length === 2) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
-         i.customId === buttonList[1].customId;
+         i.customId === buttonList[1].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else if (buttonList.length === 3) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
-         i.customId === buttonList[2].customId;
+         i.customId === buttonList[2].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else if (buttonList.length === 4) {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
          i.customId === buttonList[2].customId ||
-         i.customId === buttonList[3].customId;
+         i.customId === buttonList[3].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    } else {
       filter = (i) =>
          i.customId === buttonList[0].customId ||
          i.customId === buttonList[1].customId ||
          i.customId === buttonList[2].customId ||
          i.customId === buttonList[3].customId ||
-         i.customId === buttonList[4].customId;
+         i.customId === buttonList[4].customId &&
+         (authorIndependent && i.user.id === authorID) ||
+         !authorIndependent;
    }
    // Create collector
    const collector = await curPage.createMessageComponentCollector({

--- a/readme.md
+++ b/readme.md
@@ -127,8 +127,11 @@ pagination({
                       // if you do not want this option remove it from the function call
 
    progressBar: true, // Required if you want to use the progressBar
-   proSlider = "▣", // Optional if you want a custom progressBar
-   proBar = "▢" // Optional if you want a custom progressBar
+   proSlider: "▣", // Optional if you want a custom progressBar
+   proBar: "▢", // Optional if you want a custom progressBar
+
+   authorIndependent: true // Optional - An option to set pagination buttons only usable by the author
+                           // if you do not want this option remove it from the function call
    // Optional - An option to have the footer replaced by a progress bar
    // if you do not want this option remove it from the function call
 });
@@ -147,8 +150,10 @@ pagination({
                       // if you do not want this option remove it from the function call
 
    progressBar: true, // Required if you want to use the progressBar
-   proSlider = "▣", // Optional if you want a custom progressBar
-   proBar = "▢" // Optional if you want a custom progressBar
+   proSlider: "▣", // Optional if you want a custom progressBar
+   proBar: "▢", // Optional if you want a custom progressBar
+   authorIndependent: true // Optional - An option to set pagination buttons only usable by the author
+                           // if you do not want this option remove it from the function call
    // Optional - An option to have the footer replaced by a progress bar
    // if you do not want this option remove it from the function call
 });


### PR DESCRIPTION
This option `authorIndependent` will prevent other users from interacting to pagination not authored by them which returns interaction failed when they attempt to interact with it. This is set to `true` by default.